### PR TITLE
Allow to pass org_id in console.get_site_id

### DIFF
--- a/console.py
+++ b/console.py
@@ -37,8 +37,8 @@ def get_org_id():
     print("Selected org id: %s" %org_id)
     return org_id
 
-def get_site_id():
-    site_id = cli.select_site(session)
+def get_site_id(org_id=None):
+    site_id = cli.select_site(session, org_id=org_id)
     print("")
     print("Selected site id: %s" %site_id)
     return site_id


### PR DESCRIPTION
In case org_id is already known this makes it more convenient to get the
site_id.