### PR TITLE
add device_type filter to retrieve devices

### DIFF
--- a/mlib/requests/sites/devices.py
+++ b/mlib/requests/sites/devices.py
@@ -1,9 +1,11 @@
 
-def get(mist_session, site_id, name="", page=1, limit=100):
+def get(mist_session, site_id, name=None, device_type=None, page=1, limit=100):
     uri = "/api/v1/sites/%s/devices" % site_id
     query={}
-    if name != "":
+    if name:
         query[name] = name
+    if device_type:
+        query["type"] = device_type
     resp = mist_session.mist_get(uri, site_id=site_id, query=query, page=page, limit=limit)
     return resp
 
@@ -12,11 +14,14 @@ def get_details(mist_session, site_id, device_id):
     resp = mist_session.mist_get(uri, site_id=site_id)
     return resp
 
-def get_stats_devices(mist_session, site_id, device_id=None, page=1, limit=100):
+def get_stats_devices(mist_session, site_id, device_id=None, device_type=None, page=1, limit=100):
     uri = "/api/v1/sites/%s/stats/devices" % site_id
-    if not device_id == None:
+    query={}
+    if device_id:
         uri += "/%s" %device_id
-    resp = mist_session.mist_get(uri, site_id=site_id, page=page, limit=limit)
+    if device_type:
+        query["type"] = device_type
+    resp = mist_session.mist_get(uri, site_id=site_id, query=query, page=page, limit=limit)
     return resp
 
 def create(mist_session, site_id, devices):


### PR DESCRIPTION
to distinguish between switches and APs the following calls can be
filtered by type="ap" or type="switch".

GET /api/v1/sites/:site_id/devices
GET /api/v1/sites/:site_id/stats/devices

Therefore the parameter device_type was added to the functions get and
get_stats_devices.